### PR TITLE
Add file logging options

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -19,7 +19,7 @@ class ComposeExecutor {
         this.logger = settings.project.logger
     }
 
-    private void executeWithCustomOutput(OutputStream os, Boolean ignoreExitValue, String... args) {
+    void executeWithCustomOutput(OutputStream os, Boolean ignoreExitValue, String... args) {
         def ex = this.settings
         project.exec { ExecSpec e ->
             if (settings.dockerComposeWorkingDirectory) {
@@ -33,7 +33,10 @@ class ComposeExecutor {
             }
             finalArgs.addAll(args)
             e.commandLine finalArgs
-            e.standardOutput = os
+            if( null != os ) {
+                e.standardOutput = os
+                e.errorOutput = os
+            }
             e.ignoreExitValue = ignoreExitValue
         }
     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -45,7 +45,9 @@ class ComposeSettings {
     List<String> buildAdditionalArgs = []
     List<String> pullAdditionalArgs = []
     List<String> upAdditionalArgs = []
+    List<String> upFinalArgs = []
     List<String> downAdditionalArgs = []
+    List<String> downFinalArgs = []
     String projectName = null
 
     boolean stopContainers = true

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -48,7 +48,6 @@ class ComposeSettings {
     List<String> pullAdditionalArgs = []
     List<String> upAdditionalArgs = []
     List<String> downAdditionalArgs = []
-    List<String> downFinalArgs = []
     String projectName = null
 
     boolean stopContainers = true

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -3,6 +3,7 @@ package com.avast.gradle.dockercompose
 import com.avast.gradle.dockercompose.tasks.ComposeBuild
 import com.avast.gradle.dockercompose.tasks.ComposeDown
 import com.avast.gradle.dockercompose.tasks.ComposeDownForced
+import com.avast.gradle.dockercompose.tasks.ComposeLogs
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.avast.gradle.dockercompose.tasks.ComposeUp
 import com.avast.gradle.dockercompose.tasks.ServiceInfoCache
@@ -21,6 +22,7 @@ class ComposeSettings {
     final ComposeDownForced downForcedTask
     final ComposeBuild buildTask
     final ComposePull pullTask
+    final ComposeLogs logsTask
     final Project project
     final DockerExecutor dockerExecutor
     final ComposeExecutor composeExecutor
@@ -45,7 +47,6 @@ class ComposeSettings {
     List<String> buildAdditionalArgs = []
     List<String> pullAdditionalArgs = []
     List<String> upAdditionalArgs = []
-    List<String> upFinalArgs = []
     List<String> downAdditionalArgs = []
     List<String> downFinalArgs = []
     String projectName = null
@@ -65,6 +66,9 @@ class ComposeSettings {
     String dockerComposeWorkingDirectory = null
     Duration dockerComposeStopTimeout = Duration.ofSeconds(10)
 
+    String composeLog = null
+    String containerLogDir = null
+
     ComposeSettings(Project project, String name = '') {
         this.project = project
 
@@ -78,6 +82,8 @@ class ComposeSettings {
         downTask.settings = this
         downForcedTask = project.tasks.create(name ? "${name}ComposeDownForced" : 'composeDownForced', ComposeDownForced)
         downForcedTask.settings = this
+        logsTask = project.tasks.create(name ? "${name}ComposeLogs" : 'composeLogs', ComposeLogs)
+        logsTask.settings = this
 
         this.dockerExecutor = new DockerExecutor(this)
         this.composeExecutor = new ComposeExecutor(this)

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
@@ -46,7 +46,8 @@ class ComposeDownForced extends DefaultTask {
                     args += settings.downAdditionalArgs
                 }
                 args += settings.downFinalArgs
-                settings.composeExecutor.execute(args)
+                def composeLog = settings.composeLog ? new FileOutputStream(settings.composeLog) : null
+                settings.composeExecutor.executeWithCustomOutput(composeLog, false, args)
             } else {
                 if (!settings.startedServices.empty) {
                     settings.composeExecutor.execute(*['rm', '-f', *settings.startedServices])

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
@@ -45,6 +45,7 @@ class ComposeDownForced extends DefaultTask {
                     }
                     args += settings.downAdditionalArgs
                 }
+                args += settings.downFinalArgs
                 settings.composeExecutor.execute(args)
             } else {
                 if (!settings.startedServices.empty) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
@@ -45,7 +45,6 @@ class ComposeDownForced extends DefaultTask {
                     }
                     args += settings.downAdditionalArgs
                 }
-                args += settings.downFinalArgs
                 def composeLog = settings.composeLog ? new FileOutputStream(settings.composeLog) : null
                 settings.composeExecutor.executeWithCustomOutput(composeLog, false, args)
             } else {

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeLogs.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeLogs.groovy
@@ -1,4 +1,31 @@
 package com.avast.gradle.dockercompose.tasks
 
-class ComposeLog {
+import com.avast.gradle.dockercompose.ComposeSettings
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class ComposeLogs extends DefaultTask {
+
+  ComposeSettings settings
+
+  ComposeLogs() {
+    group = 'docker'
+    description = 'Displays log output from services in containers of docker-compose project'
+  }
+
+  @TaskAction
+  void logs() {
+
+    if( !settings.containerLogDir ) {
+      println 'Not recording container logs: containerLogDir not specified.'
+      return
+    }
+
+    settings.composeExecutor.serviceNames.each { service ->
+      println "Extracting container log from service '${service}'"
+      def logStream = new FileOutputStream("${settings.containerLogDir}/${service}.log")
+      String[] args = ['logs', '-t', service]
+      settings.composeExecutor.executeWithCustomOutput(logStream, false, args)
+    }
+  }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeLogs.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeLogs.groovy
@@ -1,0 +1,4 @@
+package com.avast.gradle.dockercompose.tasks
+
+class ComposeLog {
+}

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -59,6 +59,7 @@ class ComposeUp extends DefaultTask {
             args += settings.upAdditionalArgs
         }
         args += settings.startedServices
+        args += settings.upFinalArgs
         try {
             settings.composeExecutor.execute(args)
             startCapturing()

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -59,9 +59,9 @@ class ComposeUp extends DefaultTask {
             args += settings.upAdditionalArgs
         }
         args += settings.startedServices
-        args += settings.upFinalArgs
         try {
-            settings.composeExecutor.execute(args)
+            def composeLog = settings.composeLog ? new FileOutputStream(settings.composeLog) : null
+            settings.composeExecutor.executeWithCustomOutput(composeLog, false, args)
             startCapturing()
             def servicesToLoad = settings.startedServices ?: settings.composeExecutor.getServiceNames()
             servicesInfos = loadServicesInfo(servicesToLoad).collectEntries { [(it.name): (it)] }

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -3,9 +3,9 @@ package com.avast.gradle.dockercompose
 import com.avast.gradle.dockercompose.tasks.ComposeBuild
 import com.avast.gradle.dockercompose.tasks.ComposeDown
 import com.avast.gradle.dockercompose.tasks.ComposeDownForced
+import com.avast.gradle.dockercompose.tasks.ComposeLogs
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.avast.gradle.dockercompose.tasks.ComposeUp
-import groovy.ui.SystemOutputInterceptor
 import org.gradle.api.Task
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
@@ -25,6 +25,7 @@ class DockerComposePluginTest extends Specification {
             project.tasks.composeDownForced instanceof ComposeDownForced
             project.tasks.composePull instanceof ComposePull
             project.tasks.composeBuild instanceof ComposeBuild
+            project.tasks.composeLogs instanceof ComposeLogs
             project.extensions.findByName('dockerCompose') instanceof ComposeExtension
     }
 
@@ -43,6 +44,7 @@ class DockerComposePluginTest extends Specification {
         project.tasks.nestedComposeDownForced instanceof ComposeDownForced
         project.tasks.nestedComposePull instanceof ComposePull
         project.tasks.nestedComposeBuild instanceof ComposeBuild
+        project.tasks.nestedComposeLogs instanceof ComposeLogs
         ComposeUp up = project.tasks.nestedComposeUp
         up.settings.useComposeFiles == ['test.yml']
     }
@@ -117,6 +119,7 @@ class DockerComposePluginTest extends Specification {
         project.tasks.integrationTestComposeDownForced instanceof ComposeDownForced
         project.tasks.integrationTestComposePull instanceof ComposePull
         project.tasks.integrationTestComposeBuild instanceof ComposeBuild
+        project.tasks.integrationTestComposeLogs instanceof ComposeLogs
         ComposeUp up = project.tasks.integrationTestComposeUp
         up.settings.useComposeFiles == ['test.yml']
         task.dependsOn.contains(project.tasks.integrationTestComposeUp)


### PR DESCRIPTION
Two new options for recording logs to files:
1) Add ComposeLogs task to extract docker-compose logs to files. 
    Files are named: `<settings/containerLogDir>/<service_name>.log`
    This allows the build orchestrator (eg Jenkins) to archive these artifacts.
2) During `composeUp` and `composeDown`: 
    If `settings.composeLog` exists, redirect both `err` and `out` streams to that file.
    This allows a failed action to be logged to file for archival.